### PR TITLE
Fix package

### DIFF
--- a/tldr.el
+++ b/tldr.el
@@ -3,7 +3,7 @@
 ;; Author: Ono Hiroko <azazabc123@gmail.com>
 ;; Keywords: tools, docs
 ;; Package-Requires: ((emacs "24.3"))
-;; X-URL: http://github.com/kuanyui/fm-bookmarks.el
+;; X-URL: https://github.com/kuanyui/tldr.el
 
 ;; WTFPL 2.0
 ;; Ono Hiroko (kuanyui) (ɔ) Copyleft 2016

--- a/tldr.el
+++ b/tldr.el
@@ -101,7 +101,7 @@
   :group 'tldr-faces)
 
 
-
+;;;###autoload
 (defun tldr-update-docs ()
   "Get or update tldr docs from source."
   (interactive)
@@ -185,7 +185,7 @@ e.g. ((1 . 5) (8 . 10))"
     (nreverse res)))
 
 
-
+;;;###autoload
 (defun tldr ()
   "Lookup tldr docs."
   (interactive)

--- a/tldr.el
+++ b/tldr.el
@@ -31,7 +31,7 @@
 ;;; Code:
 
 (require 'url)
-(require 'cl)
+(require 'cl-lib)
 
 (defvar tldr-directory-path (concat user-emacs-directory "tldr/"))
 (defvar tldr-saved-zip-path (concat user-emacs-directory "tldr-source.zip"))
@@ -129,15 +129,15 @@
 (defun tldr-get-commands-list ()
   "For `completing-read'"
   (mapcar (lambda (file.md) (substring file.md 0 -3))
-          (remove-if (lambda (y) (member y '("." "..")))
-                     (mapcan (lambda (x) (directory-files (concat tldr-pages-dir x)))
-                             (tldr-get-system-name)))))
+          (cl-remove-if (lambda (y) (member y '("." "..")))
+                        (cl-mapcan (lambda (x) (directory-files (concat tldr-pages-dir x)))
+                                   (tldr-get-system-name)))))
 
 (defun tldr-get-file-path-from-command-name (command)
-  (find-if #'file-exists-p
-           (mapcar (lambda (system-name)
-                     (format "%s%s/%s.md" tldr-pages-dir system-name command))
-                   (tldr-get-system-name))))
+  (cl-find-if #'file-exists-p
+              (mapcar (lambda (system-name)
+                        (format "%s%s/%s.md" tldr-pages-dir system-name command))
+                      (tldr-get-system-name))))
 
 (defun tldr-render-markdown (command)
   (let* ((file-path (tldr-get-file-path-from-command-name command))

--- a/tldr.el
+++ b/tldr.el
@@ -45,7 +45,8 @@
 (defgroup tldr nil
   "tldr client for Emacs"
   :prefix "tldr-"
-  :link '(url-link "http://github.com/kuanyui/tldr.el"))
+  :link '(url-link "http://github.com/kuanyui/tldr.el")
+  :group 'help)
 
 (defgroup tldr-faces nil
   ""

--- a/tldr.el
+++ b/tldr.el
@@ -2,7 +2,7 @@
 
 ;; Author: Ono Hiroko <azazabc123@gmail.com>
 ;; Keywords: tools, docs
-;; Package-Requires: ((emacs "24.5") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "24.3"))
 ;; X-URL: http://github.com/kuanyui/fm-bookmarks.el
 
 ;; WTFPL 2.0

--- a/tldr.el
+++ b/tldr.el
@@ -135,8 +135,8 @@
 
 (defun tldr-get-file-path-from-command-name (command)
   (cl-find-if #'file-exists-p
-              (mapcar (lambda (system-name)
-                        (format "%s%s/%s.md" tldr-pages-dir system-name command))
+              (mapcar (lambda (system)
+                        (format "%s%s/%s.md" tldr-pages-dir system command))
                       (tldr-get-system-name))))
 
 (defun tldr-render-markdown (command)

--- a/tldr.el
+++ b/tldr.el
@@ -143,7 +143,7 @@
   (let* ((file-path (tldr-get-file-path-from-command-name command))
          (lines (split-string
                  (with-temp-buffer
-                   (insert-file-contents (tldr-get-file-path-from-command-name command))
+                   (insert-file-contents file-path)
                    (buffer-string)) "\n")))
 
     (mapconcat (lambda (line)


### PR DESCRIPTION
- Use cl-lib instead of cl
- Add autoload cookie for lazy loadyng
- Specify parent group
- Fix some byte-compile warnings
- Fix package URL
- Correct minimum Emacs version

There are some byte-compile warnings in original code.

```
tldr.el:34:1:Warning: cl package required at runtime
tldr.el:45:1:Warning: defgroup for ‘tldr’ fails to specify containing group
tldr.el:136:1:Warning: Lexical argument shadows the dynamic variable system-name

In tldr-get-file-path-from-command-name:
tldr.el:139:58:Warning: ‘system-name’ is an obsolete variable (as of 25.1);
    use (system-name) instead
tldr.el:142:1:Warning: Unused lexical variable ‘file-path’
```
