### PR TITLE
Remove unneeded args for completing-read

### DIFF
--- a/tldr.el
+++ b/tldr.el
@@ -210,7 +210,7 @@ e.g. ((1 . 5) (8 . 10))"
 Please wait a minute for downloading latest tldr docs...")
         (sit-for 3)
         (tldr-update-docs)))
-  (let ((command (completing-read "tldr: " (tldr-get-commands-list) nil t "" nil t)))
+  (let ((command (completing-read "tldr: " (tldr-get-commands-list) nil t)))
     (with-temp-buffer-window "*tldr*" nil nil)
     (if (not (equal (buffer-name) "*tldr*"))
         (switch-to-buffer-other-window "*tldr*"))


### PR DESCRIPTION
We don't need to set INITIAL-INPUT and DEF, though it usually isn't
really harmful, except with helm-mode: if DEF is set to t, helmize
completing-read will think "t" is a command as well, which is obviously
wrong.
