### PR TITLE
Add history navigation buttons

### DIFF
--- a/tldr.el
+++ b/tldr.el
@@ -185,11 +185,8 @@
                               (mapc (lambda (pos)
                                       (set-text-properties (car pos) (cdr pos) '(face tldr-command-argument) line))
                                     brackets-positions))
-                          (concat "  " (replace-regexp-in-string "{{\\(.+?\\)}}" "\\1" line))
-                          )))
-                 )
-               lines "\n")
-    ))
+                          (concat "  " (replace-regexp-in-string "{{\\(.+?\\)}}" "\\1" line))))))
+               lines "\n")))
 
 (defun tldr-match-positions (regexp str)
   "Get all matched regexp groups positions grabbed with \\(\\)
@@ -200,8 +197,7 @@ e.g. ((1 . 5) (8 . 10))"
                 (< pos (length str) ) )
       (let ((m (match-end 0)))
         (push (cons (match-beginning 0) (1- m)) res)
-        (setq pos m)
-        ))
+        (setq pos m)))
     (nreverse res)))
 
 
@@ -246,8 +242,7 @@ Please wait a minute for downloading latest tldr docs...")
               (insert "\t"))
             (help-insert-xref-button help-forward-label 'help-forward
                                      (current-buffer)))
-          (goto-char (point-min)))
-        ))))
+          (goto-char (point-min)))))))
 
 (provide 'tldr)
 ;;; tldr.el ends here

--- a/tldr.el
+++ b/tldr.el
@@ -235,6 +235,17 @@ Please wait a minute for downloading latest tldr docs...")
 
         (let (buffer-read-only)
           (insert (tldr-render-markdown command))
+          (insert "\n")
+          ;; Make a back-reference in this buffer if appropriate.
+          (when help-xref-stack
+            (help-insert-xref-button help-back-label 'help-back
+                                     (current-buffer)))
+          ;; Make a forward-reference in this buffer if appropriate.
+          (when help-xref-forward-stack
+            (when help-xref-stack
+              (insert "\t"))
+            (help-insert-xref-button help-forward-label 'help-forward
+                                     (current-buffer)))
           (goto-char (point-min)))
         ))))
 


### PR DESCRIPTION
The new added code is all from help-mode.el, and here is what it looks like:
![screen shot 2016-02-10 at 23 17 44](https://cloud.githubusercontent.com/assets/4550353/12951300/a5e45206-d04c-11e5-801c-e0ad27d6d7bf.png)
