### PR TITLE
fix rename directory error when first time running or update doc

### DIFF
--- a/tldr.el
+++ b/tldr.el
@@ -144,7 +144,7 @@
         (url-copy-file tldr-source-zip-url tldr-saved-zip-path 'overwrite)
         (shell-command (format "unzip -d %s %s" (file-truename user-emacs-directory) tldr-saved-zip-path))
         (delete-file tldr-saved-zip-path)
-        (rename-file (concat (file-truename user-emacs-directory) "tldr-master") tldr-directory-path)
+        (shell-command (format "mv %s %s" (concat (file-truename user-emacs-directory) "tldr-master") tldr-directory-path))
         (message "Now tldr docs is updated!"))))
 
 

--- a/tldr.el
+++ b/tldr.el
@@ -144,7 +144,7 @@
         (url-copy-file tldr-source-zip-url tldr-saved-zip-path 'overwrite)
         (shell-command (format "unzip -d %s %s" (file-truename user-emacs-directory) tldr-saved-zip-path))
         (delete-file tldr-saved-zip-path)
-        (shell-command (format "mv %s %s" (concat (file-truename user-emacs-directory) "tldr-master") tldr-directory-path))
+        (shell-command (format "mv '%s' '%s'" (concat (file-truename user-emacs-directory) "tldr-master") tldr-directory-path))
         (message "Now tldr docs is updated!"))))
 
 


### PR DESCRIPTION
when I ran ~tldr~ for the first time, I got error from emacs:
```
Debugger entered--Lisp error: (file-missing "Renaming" "No such file or directory" "/Users/showgood/.emacs.d/tldr-master" "/Users/showgood/.emacs.d/tldr/tldr-master")
  rename-file("/Users/showgood/.emacs.d/tldr-master" "/Users/showgood/.emacs.d/tldr/")
```

Reason is because that's the behavior for ~rename-file~ according to elisp doc:
```
Rename FILE as NEWNAME.  Both args must be strings.
If file has names other than FILE, it continues to have those names.
If NEWNAME is a directory name, rename FILE to a like-named file under
NEWNAME.
```

basically after this rename-file call, we have the directory:
```
Users/showgood/.emacs.d/tldr/tldr-master
```
instead of 
```
Users/showgood/.emacs.d/tldr/
```

didn't find an easy way to fix in elisp, but using `mv` would fix it.