### PR TITLE
Fix download of tldr source

### DIFF
--- a/tldr.el
+++ b/tldr.el
@@ -154,7 +154,7 @@ source."
         (url-copy-file tldr-source-zip-url tldr-saved-zip-path)
         (shell-command-to-string (format "unzip -d %s %s" (file-truename user-emacs-directory) tldr-saved-zip-path))
         (delete-file tldr-saved-zip-path)
-        (shell-command-to-string (format "mv '%s' '%s'" (concat (file-truename user-emacs-directory) "tldr-master") tldr-directory-path))
+        (shell-command-to-string (format "mv '%s' '%s'" (concat (file-truename user-emacs-directory) "tldr-main") tldr-directory-path))
         (message "The TLDR docs are up to date!"))))
 
 


### PR DESCRIPTION
There was 4 issues:
- `tldr-source-zip-url` needed to be updated
- the root  branch got renamed from `master` to `main`
- `tldr-request-data` is async so the subsequent sync unzip attempt would never work on first try
   I initially attempted to solve it wo/ moving all the post processing in the callback, by using [`request-deferred`](https://github.com/tkf/emacs-request/blob/master/request-deferred.el), but...
- no matter what I tried, `request` would corrupt the downloaded zip header

The 2 last items got fixed by replacing `request` by `url-copy-file`.

Should I hope fix https://github.com/kuanyui/tldr.el/issues/29.