### PR TITLE
Adding a description/annotation for each command 

### DIFF
--- a/tldr.el
+++ b/tldr.el
@@ -229,7 +229,7 @@ the default English language page."
                         (setq line (propertize (substring line 1 -1) 'face 'tldr-code-block))
                         ;; Add command face
                         (setq line (replace-regexp-in-string
-                                    (concat "^" command)
+                                    (concat "^" (regexp-quote command))
                                     (propertize command 'face 'tldr-command-itself)
                                     line 'fixedcase))
                         ;; Strip {{}} and add command argument face


### PR DESCRIPTION
This is a PR for #38 - Adding a description/annotation for each command.

- User option `tldr-enable-annotations` default to `t` as no visible perf degradation was seen on two machines: `GNU Emacs 28.2 (build 2, aarch64-apple-darwin21.3.0)` and `GNU Emacs 27.1 (build 1, x86_64-pc-linux-gnu, GTK+ Version 2.24.23)`